### PR TITLE
fix: discriminate calls from jumps via rd, rewrite trace state machine

### DIFF
--- a/src/rv_profile/decoder.py
+++ b/src/rv_profile/decoder.py
@@ -1,0 +1,90 @@
+"""Instruction classifier for RISC-V control-flow tracking.
+
+Each fetched instruction is classified into one of a small number of "kinds".
+The trace processor uses the classification of the *previous* instruction to
+decide what control-flow transition just landed it at the current PC, which
+is what makes it possible to distinguish a real function call (jal/jalr with
+rd in the link-register set) from an unconditional jump or a tail call
+(jal/jalr with rd == x0).
+"""
+
+# Instruction kinds.
+NORMAL = "NORMAL"
+CALL = "CALL"
+RET = "RET"
+JUMP = "JUMP"      # unconditional jump that does not write a link register
+BRANCH = "BRANCH"  # conditional branch
+
+# RISC-V psABI link registers: ra (x1) and t0 (x5).
+LINK_REGS = (1, 5)
+
+MRET = 0x30200073
+
+
+def classify(instr):
+    """Classify a fetched RISC-V instruction.
+
+    `instr` may be a 32-bit standard encoding or a 16-bit compressed encoding
+    placed in the lower halfword of a 32-bit word. Some cores expose the
+    instruction with the next halfword in the upper bits; that's fine, the
+    quadrant bits in the low halfword still discriminate compressed vs.
+    standard.
+    """
+    if instr == MRET:
+        return RET
+
+    low = instr & 0xFFFF
+    if (low & 0x3) != 0x3:
+        return _classify_compressed(low)
+
+    return _classify_standard(instr)
+
+
+def _classify_compressed(c):
+    funct3 = (c >> 13) & 0x7
+    quadrant = c & 0x3
+
+    # Quadrant 1: c.j / c.jal / c.beqz / c.bnez
+    if quadrant == 0b01:
+        if funct3 == 0b101:        # c.j  (rd = x0)
+            return JUMP
+        if funct3 == 0b001:        # c.jal (rd = ra) — RV32 only
+            return CALL
+        if funct3 in (0b110, 0b111):  # c.beqz / c.bnez
+            return BRANCH
+
+    # Quadrant 2: c.jr / c.jalr live under funct3 == 100. The same funct3
+    # also encodes c.mv / c.add / c.ebreak; we filter those out by requiring
+    # rs2 == 0 and rs1 != 0.
+    if quadrant == 0b10 and funct3 == 0b100:
+        funct4 = (c >> 12) & 0xF
+        rs1 = (c >> 7) & 0x1F
+        rs2 = (c >> 2) & 0x1F
+        if rs1 != 0 and rs2 == 0:
+            if funct4 == 0b1000:   # c.jr  rs1 (rd implicit x0)
+                return RET if rs1 in LINK_REGS else JUMP
+            if funct4 == 0b1001:   # c.jalr rs1 (rd implicit ra)
+                return CALL
+
+    return NORMAL
+
+
+def _classify_standard(instr):
+    opcode = instr & 0x7F
+    rd = (instr >> 7) & 0x1F
+    rs1 = (instr >> 15) & 0x1F
+
+    if opcode == 0b1101111:        # JAL
+        return CALL if rd in LINK_REGS else JUMP
+
+    if opcode == 0b1100111:        # JALR
+        if rd in LINK_REGS:
+            return CALL
+        if rd == 0 and rs1 in LINK_REGS:
+            return RET
+        return JUMP                # rd=x0 with non-link rs1: indirect jump / tail call
+
+    if opcode == 0b1100011:        # BRANCH (beq/bne/blt/bge/bltu/bgeu)
+        return BRANCH
+
+    return NORMAL

--- a/src/rv_profile/rv_profile.py
+++ b/src/rv_profile/rv_profile.py
@@ -1,350 +1,160 @@
 #!/bin/python
-from wal.core import Wal, WalEvalError
+"""Cycle-accurate RISC-V function profiler.
+
+The trace processor is driven event-by-event. For each fired clock we receive
+(pc, instr, mcycle); the kind of the *previous* instruction tells us what
+control-flow transition just landed us at the current pc. This avoids the
+buffer-and-look-ahead state machine the previous implementation needed and
+naturally distinguishes calls (rd in {ra, t0}) from unconditional jumps and
+tail calls (rd == x0).
+"""
+
+import bisect
 import os
 import subprocess
+
 from rv_profile.CallStack import CallStack
-
-RET=(0x8082, 0x8067)
-MRET=(0x30200073,)
-CALL=(0b1100111, 0b1101111)
-BR=(0b1100011,)
-
-
-BR_BUFF_LENGTH = 2
-CALL_BUFF_LENGTH = 1
-RET_BUFF_LENGTH = 1
+from rv_profile.decoder import classify, CALL, RET, JUMP, BRANCH
 
 DEBUG = False
 
 
 def ranges(binary_file):
-    '''This functions extracts the functions from elf files using "nm"'''
-    res = []
+    """Extract function symbols and their address ranges from an ELF using nm."""
+    nm_bin = os.environ.get('RISCV_PREFIX', '') + 'nm'
+    try:
+        proc = subprocess.Popen([nm_bin, '-S', binary_file], stdout=subprocess.PIPE)
+    except FileNotFoundError:
+        print(f'"{nm_bin}" not found on system')
+        exit(1)
 
-    if 'RISCV_PREFIX' in os.environ:
-        proc = subprocess.Popen( [ os.environ['RISCV_PREFIX'] + 'nm' , '-S', binary_file], stdout=subprocess.PIPE )
-    else:
-        # print('Please add the location of you RISC-V toolchain to the "RISCV_PREFIX" variable.')
-        # print('Now trying to fall back to the regular "nm"..\n')
-        try:
-            proc = subprocess.Popen( [ 'nm' , '-S', binary_file], stdout=subprocess.PIPE )
-        except:
-            print('"nm" not found on system')
-            exit(1)
-        
     stdout, _ = proc.communicate()
-    symbols = stdout.decode('UTF-8')
-
-    for line in symbols.split('\n'):
+    res = []
+    for line in stdout.decode('UTF-8').split('\n'):
         cols = line.split()
-        if len(cols) == 4 and cols[2] in ['T', 't']:
+        if len(cols) == 4 and cols[2] in ('T', 't'):
             name = cols[3]
             start = int(cols[0], 16)
+            # Highest legal PC inside the function. Subtracting 2 covers the
+            # case where the last instruction is a 16-bit compressed insn;
+            # alignment guarantees no aliasing with the next function.
             end = start + int(cols[1], 16) - 2
             res.append([name, start, end])
-
     return res
 
 
+class TraceProcessor:
+    """Drives a CallStack from a stream of (pc, instr, mcycle) events.
+
+    Maintains a single-instruction lookback so that the *kind* of the
+    previous instruction tells the processor what control-flow transition
+    landed it at the current pc. The class is intentionally side-effect free
+    on construction so it can be exercised from tests with synthetic events.
+    """
+
+    def __init__(self, functions, callstack=None):
+        self.cs = callstack or CallStack(verbose=False)
+        sorted_funcs = sorted(functions, key=lambda f: f[1])
+        self._sorted = sorted_funcs
+        self._starts = [f[1] for f in sorted_funcs]
+        self._prev_pc = None
+        self._prev_instr = None
+        self._prev_kind = None
+        self._prev_func = None
+
+    def func_at(self, addr):
+        """Return the function name containing `addr`, or None."""
+        i = bisect.bisect_right(self._starts, addr) - 1
+        if i < 0:
+            return None
+        name, _lo, hi = self._sorted[i]
+        if addr <= hi:
+            return name
+        return None
+
+    def feed(self, addr, instr, mcycle):
+        # Pipeline stalls re-fire the same (pc, instr) for several cycles;
+        # skip duplicates so we don't synthesize spurious self-loops.
+        if self._prev_pc == addr and self._prev_instr == instr:
+            return
+
+        cur_func = self.func_at(addr)
+
+        if cur_func is None:
+            # PC outside any nm-known function (trap vector, ROM stub, …).
+            # We still classify the instruction so that a return-out-of-trap
+            # can be picked up at the next known PC, but we don't touch the
+            # call stack here.
+            self._prev_pc = addr
+            self._prev_instr = instr
+            self._prev_kind = classify(instr)
+            self._prev_func = None
+            return
+
+        prev_kind = self._prev_kind
+        prev_func = self._prev_func
+
+        if self._prev_pc is None:
+            # First observed instruction: push the entry function.
+            self.cs.call(cur_func, addr, mcycle)
+        elif prev_kind == CALL:
+            # Previous instruction wrote a link register; the current pc is
+            # the callee entry point.
+            self.cs.call(cur_func, addr, mcycle)
+        elif prev_kind == RET:
+            # Pop frames until cur_func is on top of the stack.
+            self.cs.ret(cur_func, addr, mcycle)
+        elif prev_kind in (JUMP, BRANCH):
+            # rd=x0 jump or branch. If we crossed a function boundary it's
+            # a tail call (or, in pathological code, a branch into another
+            # function); replace the current frame with the new one.
+            if cur_func != prev_func:
+                self.cs.ret(cur_func, addr, mcycle)
+        else:
+            # Sequential execution. cur_func should equal prev_func; if it
+            # doesn't we silently fell through into another function (alias
+            # symbol, contiguous functions). Push it as an implicit call.
+            if cur_func != prev_func:
+                self.cs.call(cur_func, addr, mcycle)
+
+        self._prev_pc = addr
+        self._prev_instr = instr
+        self._prev_kind = classify(instr)
+        self._prev_func = cur_func
+
 
 def riscv_profile_main(elf, fst, cfg, output, step):
-    BIN         = elf
-    VCD         = fst
-    CFG_FILE    = cfg
-    FG_DATA     = output
+    # Lazy-import so the rest of this module (TraceProcessor, classify, ranges)
+    # remains usable in test environments that don't ship the wal-lang dep.
+    from wal.core import Wal, WalEvalError
 
-    cs      = CallStack(verbose=False)
-    functions = ranges(BIN)
-    buffer  = []
-    state = None # Can be BR, CALL, RET
-    last = None
-    buffer_flushed = False
+    functions = ranges(elf)
+    processor = TraceProcessor(functions)
 
-    wal     = Wal()
-    wal.load(VCD)
-    
+    wal = Wal()
+    wal.load(fst)
 
     try:
-        wal.eval_str(f'(eval-file {CFG_FILE})') # require config script to get concrete signal names
+        wal.eval_str(f'(eval-file {cfg})')
     except WalEvalError as e:
-        # Print in red the error message
         print(f"\033[91m{e}\033[0m")
         exit(1)
 
     def count_function(seval, args):
-        nonlocal buffer
-        nonlocal state
-        nonlocal last
-        nonlocal buffer_flushed
-
         addr = seval.eval(args[0])
         instr = seval.eval(args[1])
         mcycle = seval.eval(args[2])
-
-        print(f"[????] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}") if DEBUG else None
-
-        if (last is not None and last[1] == instr and last[0] == addr and not buffer_flushed):
-            return
-
-        buffer_flushed = False
-
-        found = False
-        for function in functions:
-            if addr >= function[1] and addr <= function[2]:
-                found = True
-
-        if (not found): 
-            print("Ignoring instr") if DEBUG else None
-            return
-
-        assert (len(buffer) <= max(BR_BUFF_LENGTH, CALL_BUFF_LENGTH, RET_BUFF_LENGTH)+1)
-
-        last = (addr, instr, mcycle)
-        
-        if (state == "BR"):
-            """
-            If the state is BR, then push until the buffer has length
-            BR_BUFF_LENGTH, if at that point the pc has not changed then we can
-            assume that the branch was not taken and we can pop the buffer and
-            add those instructions to the call stack.
-
-            Else if, at some point the pc changes, then we can assume that the
-            branch was taken and we can pop the buffer and ignore those
-            instructions.
-            """
-            if (len(buffer) < BR_BUFF_LENGTH+1):
-                print("[BR] Appending to buffer") if DEBUG else None
-                buffer.append((addr, instr, mcycle))
-
-            if (len(buffer) == BR_BUFF_LENGTH+1):
-                print("[BR] Buffer full") if DEBUG else None
-                """
-                Check if addresses in the buffer are contiguous, if they are
-                then the branch was not taken and we can pop the buffer and add
-                the instructions to the call stack.
-                """
-                taken = False
-                another_func = False
-                br_addr, _, _ = buffer[0]
-                for function in functions:
-                    if br_addr >= function[1] and br_addr <= function[2]:
-                        br_func = function[0]
-                        break
-
-                buffer = buffer[1:]
-
-                last_addr = br_addr
-                taken_i = 0
-                for i in range(len(buffer)):
-                    addr, instr, mcycle = buffer[i]
-
-                    if (addr != last_addr+4 and addr != last_addr+2):
-                        # Check if another function is called instead
-                        print(hex(addr), hex(last_addr)) if DEBUG else None
-                        for function in functions:
-                            if addr >= function[1] and addr <= function[2]:
-                                if (function[0] != br_func):
-                                    another_func = True
-                                break
-                        
-                        if (another_func):
-                            print("[BR] Another function called") if DEBUG else None
-                            break
-
-                        taken = True
-                        taken_i = i
-                        break
-                    last_addr = addr
-
-                
-                if (taken):
-                    print(f"[BR] Branch taken: {taken}") if DEBUG else None
-                
-                if (another_func):
-                    print("[BR] Branch is not a real branch, entered another function") if DEBUG else None
-
-                    # Iterate the buffer until we meet a CALL/RET instruction
-                    for i in range(len(buffer)):
-                        addr, instr, mcycle = buffer[i]
-                        opcode = instr & 0x7F
-
-                        print(f"[BR] Checking for corner case: {hex(addr)}, {hex(instr)}") if DEBUG else None
-                        if (instr in set(RET + MRET) or opcode in set(CALL)):
-                            print("[BR] Stopping at corner case") if DEBUG else None
-                            buffer = buffer[i:]
-
-                            if (instr in set(RET + MRET)):
-                                state = "RET"
-                            elif (opcode in set(CALL)):
-                                state = "CALL"
-                            break
-                    
-                    # # Replay as a RET
-                    # state = "RET"
-
-                    taken = None
-
-                
-                if (taken is not None):
-                    if (not taken):
-                        """
-                        If the branch was not taken, then for each instruction, until
-                        we meet a branch instruction/ret/call instruction, we can add
-                        the instructions to the call stack.
-                        """
-                        for i in range(len(buffer)-1):
-                            addr, instr, mcycle = buffer[i]
-
-                            # Check if it is a corner-case, stop looping
-                            if (instr in set(BR+ CALL+ RET+ MRET)):
-                                print("[BR] Stopping at corner case") if DEBUG else None
-                                buffer = buffer[i:]
-                                break
-                            else: # Add to call stack
-                                print(f"[BR] Adding to call stack: {hex(addr)}") if DEBUG else None
-                                for function in functions:
-                                    if addr >= function[1] and addr <= function[2]:
-                                        cs.call(function[0], addr, mcycle)
-                                        break
-
-                        addr, instr, mcycle = buffer[-1]
-                        buffer_flushed = True
-                        buffer = []
-                        state = None
-                    else: # Ignore all instructions in the buffer except last
-                        # The last one overrides addr, instr, mcycle
-                        addr, instr, mcycle = buffer[taken_i]
-                        buffer = [] # Empty the buffer
-                        buffer_flushed = True
-                        print(f"[BR] Ignoring instructions in buffer, except last: {hex(addr)}") if DEBUG else None
-                    
-                    state = None
-        if (state == "CALL"):
-            """
-            If the state is CALL, then push until the buffer has length
-            CALL_BUFF_LENGTH, the PC will change at some point, which will be
-            corresponding to the delay slot of the call instruction.
-
-            When the buffer is full, we can pop the buffer ignoring all the
-            instructions with PC continous to the call instruction, and add the
-            rest to the call stack.
-            """
-            if (len(buffer) < CALL_BUFF_LENGTH+1):
-                buffer.append((addr, instr, mcycle))
-                print("[CALL] Appending to buffer, length: ", len(buffer)) if DEBUG else None
-            
-            if (len(buffer) == CALL_BUFF_LENGTH+1):
-                print("[CALL] Buffer full") if DEBUG else None
-                # Execute a first call to the oldest instruction in the buffer
-                addr, instr, mcycle = buffer[0]
-                print(f"[CALL] Adding to call stack: {hex(addr)}") if DEBUG else None
-                for function in functions:
-                    if addr >= function[1] and addr <= function[2]:
-                        cs.call(function[0], addr, mcycle)
-                        break
-                
-                buffer = buffer[1:]
-
-                assert (len(buffer) == 1)
-                
-                addr, instr, mcycle = buffer[-1]
-                buffer = []
-                state = None
-        if (state == "RET"):
-            """Use the same algorithm as for CALL instructions."""
-            if (len(buffer) < RET_BUFF_LENGTH+1):
-                print("[RET] Appending to buffer") if DEBUG else None
-                buffer.append((addr, instr, mcycle))
-            
-            if (len(buffer) == RET_BUFF_LENGTH+1):
-                print("[RET] Buffer full") if DEBUG else None
-
-                for b in buffer:
-                    addr, instr, mcycle = b
-                    print(f"[RET] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}") if DEBUG else None
-
-                # Execute the RET
-                addr, instr, mcycle = buffer[1]
-
-                for function in functions:
-                    if addr >= function[1] and addr <= function[2]:
-                        print(f"[RET] Returning to: {function[0]}") if DEBUG else None
-                        cs.ret(function[0], addr, mcycle)
-                        break
-
-                # assert (len(buffer) == 1)
-
-                # Execute this last instruction
-                if (len(buffer) > 0):
-                    addr, instr, mcycle = buffer[-1]
-                    print(f"[RET] Execute last instruction: {hex(addr)}") if DEBUG else None
-                    buffer = []
-                    state = None
-                else:
-                    print("[RET] No instructions in buffer") if DEBUG else None
-                    state = None
-                    return
-
-        #Get the opcode from the instr
-        opcode = instr & 0x7F
-
-        if (state is not None):
-            return
-
-        if (instr in RET or instr in MRET):
-            """A return instruction is detected, keep accepting new instructions
-            until the buffer is full.
-            """
-            state = "RET"
-            buffer.insert(0, (addr, instr, mcycle)) # Use insert rather than append bc the buffer might not be empty
-            print(f"[RET] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}, state: {state}") if DEBUG else None
-            return
-        elif (opcode in BR):
-            """A branch instruction is detected, keep accepting new instructions
-            until the buffer is full.
-            """
-            state = "BR"
-            buffer.append((addr, instr, mcycle))
-            print(f"[BR] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}, state: {state}") if DEBUG else None
-            return
-        elif (opcode in CALL):
-            """A call instruction is detected, keep accepting new instructions"
-            """
-            state = "CALL"
-            buffer.append((addr, instr, mcycle))
-            print(f"[CALL] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}, state: {state}") if DEBUG else None
-            return
-        else:
-            state = None
-
-        # if (len(buffer) == 1):
-        #     buffer.pop()
-
-        #     # Return with the new func name
-        #     for function in functions:
-        #         if addr >= function[1] and addr <= function[2]:
-        #             cs.ret(function[0], addr, mcycle)
-        
-        # if (instr in RET or instr in MRET):
-        #     if (len(buffer) == 0):
-        #         # buffer and wait for the next instruction
-        #         buffer.append(addr)
-        #         return
-
-            for function in functions:
-                if addr >= function[1] and addr <= function[2]:
-                        print(f"[NONE] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}") if DEBUG else None
-                        cs.call(function[0], addr, mcycle)
-                        return
+        if DEBUG:
+            print(f"[????] addr: {hex(addr)} instr: {hex(instr)}, mcycle: {mcycle}")
+        processor.feed(addr, instr, mcycle)
 
     wal.step(step)
-
     wal.register_operator("count-function", count_function)
 
     try:
-        instructions_executed = wal.eval_str('(whenever (fire) (count-function pc instr mcycle))', funcs=functions)
+        wal.eval_str('(whenever (fire) (count-function pc instr mcycle))', funcs=functions)
     except WalEvalError as e:
         print(e)
         exit(1)
 
-    cs.generate_flamegraph_data(FG_DATA)
+    processor.cs.generate_flamegraph_data(output)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,0 +1,130 @@
+"""Unit tests for rv_profile.decoder.classify."""
+
+from rv_profile.decoder import (
+    BRANCH,
+    CALL,
+    JUMP,
+    NORMAL,
+    RET,
+    classify,
+)
+
+
+def encode_jal(rd):
+    """JAL with imm = 0; only rd matters for classification."""
+    return ((rd & 0x1F) << 7) | 0x6F
+
+
+def encode_jalr(rd, rs1):
+    return ((rs1 & 0x1F) << 15) | ((rd & 0x1F) << 7) | 0x67
+
+
+# ----- standard 32-bit encodings ------------------------------------------------
+
+def test_jal_ra_is_call():
+    assert classify(encode_jal(rd=1)) == CALL
+
+
+def test_jal_t0_is_call():
+    assert classify(encode_jal(rd=5)) == CALL
+
+
+def test_jal_x0_is_jump():
+    # `j label` — unconditional jump or tail call, not a call
+    assert classify(encode_jal(rd=0)) == JUMP
+
+
+def test_jal_other_rd_is_jump():
+    assert classify(encode_jal(rd=10)) == JUMP
+
+
+def test_canonical_ret():
+    # `ret` == jalr x0, 0(ra)
+    assert classify(0x00008067) == RET
+
+
+def test_jalr_x0_t0_is_ret():
+    # the t0-link return form
+    assert classify(encode_jalr(rd=0, rs1=5)) == RET
+
+
+def test_jalr_x0_other_rs1_is_jump():
+    # indirect jump (switch table, function pointer tail call) — not a return
+    assert classify(encode_jalr(rd=0, rs1=10)) == JUMP
+
+
+def test_jalr_ra_is_call():
+    # jalr ra, 0(a0) — function pointer call
+    assert classify(encode_jalr(rd=1, rs1=10)) == CALL
+
+
+def test_branch_opcode():
+    # beq x0, x0, 0
+    assert classify(0x00000063) == BRANCH
+
+
+def test_mret():
+    assert classify(0x30200073) == RET
+
+
+def test_nop_is_normal():
+    assert classify(0x00000013) == NORMAL
+
+
+def test_addi_is_normal():
+    # addi a0, a0, 1
+    assert classify(0x00150513) == NORMAL
+
+
+# ----- compressed encodings -----------------------------------------------------
+
+def test_c_jr_ra_is_ret():
+    # c.jr ra — compressed `ret`
+    assert classify(0x8082) == RET
+
+
+def test_c_jr_t0_is_ret():
+    # c.jr t0 — also a return form
+    assert classify(0x8282) == RET
+
+
+def test_c_jr_a0_is_jump():
+    # c.jr a0 — indirect jump, not a return
+    assert classify(0x8502) == JUMP
+
+
+def test_c_jalr_ra_is_call():
+    # c.jalr ra — compressed call (rd implicit ra)
+    assert classify(0x9082) == CALL
+
+
+def test_c_j_is_jump():
+    # c.j +0
+    assert classify(0xA001) == JUMP
+
+
+def test_c_beqz_is_branch():
+    # c.beqz x8, +0
+    assert classify(0xC001) == BRANCH
+
+
+def test_c_add_is_normal():
+    # c.add a0, a1 — same funct3/quadrant family as c.jalr but rs2 != 0
+    # encoding: 1001 a0(01010) a1(01011) 10 = 1001_0101_0010_1110 = 0x952E
+    assert classify(0x952E) == NORMAL
+
+
+def test_c_mv_is_normal():
+    # c.mv a0, a1 — funct4=1000, rs2 != 0 (same family as c.jr)
+    # 1000 01010 01011 10 = 1000_0101_0010_1110 = 0x852E
+    assert classify(0x852E) == NORMAL
+
+
+# ----- robustness ---------------------------------------------------------------
+
+def test_compressed_with_garbage_in_upper_bits():
+    """Some cores expose `instr` as 32 bits with the next halfword in the
+    upper bits. classify() must dispatch on the low halfword's quadrant bits
+    and ignore the upper bits for compressed instructions."""
+    assert classify(0xDEAD8082) == RET
+    assert classify(0xCAFE9082) == CALL

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -1,0 +1,214 @@
+"""End-to-end tests for the TraceProcessor state machine.
+
+These tests fabricate (pc, instr, mcycle) streams against a tiny synthetic
+function table and check that the resulting CallStack matches what a sane
+profiler would record. They run without WAL or any FST file.
+"""
+
+from rv_profile.CallStack import CallStack
+from rv_profile.rv_profile import TraceProcessor
+
+
+# Synthetic function table: name, start, end_inclusive (last legal PC).
+FUNCS = [
+    ["main", 0x100, 0x140],
+    ["foo",  0x200, 0x240],
+    ["bar",  0x300, 0x340],
+    ["baz",  0x400, 0x440],
+]
+
+# Canonical encodings used throughout the tests.
+NOP        = 0x00000013          # addi x0, x0, 0
+JAL_RA     = 0x000000EF          # jal  ra, 0  (real call)
+JAL_X0     = 0x0000006F          # jal  x0, 0  (j label / tail call)
+RET_INSTR  = 0x00008067          # jalr x0, 0(ra) — `ret`
+JALR_RA_A0 = 0x000500E7          # jalr ra, 0(a0) — function pointer call
+JR_A0      = 0x00050067          # jalr x0, 0(a0) — indirect jump / tail call
+BEQ        = 0x00000063          # beq  x0, x0, 0
+
+
+def stack_names(p):
+    return [name for name, _addr, _t in p.cs.stack]
+
+
+def history_strings(p):
+    return [s for s, _d in p.cs.call_stack_history]
+
+
+def feed(p, events):
+    for ev in events:
+        p.feed(*ev)
+
+
+# ----- basic call/return --------------------------------------------------------
+
+def test_first_event_pushes_function():
+    p = TraceProcessor(FUNCS)
+    p.feed(0x100, NOP, 0)
+    assert stack_names(p) == ["main"]
+
+
+def test_simple_call_then_return():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,       0),    # main entry
+        (0x104, JAL_RA,    1),    # main: call foo
+        (0x200, NOP,       2),    # foo entry
+        (0x204, RET_INSTR, 3),    # foo: ret
+        (0x108, NOP,       4),    # back in main
+    ])
+    assert stack_names(p) == ["main"]
+    assert any(s.endswith("main;foo") for s in history_strings(p))
+
+
+def test_nested_calls():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,       0),
+        (0x104, JAL_RA,    1),    # main → foo
+        (0x200, NOP,       2),
+        (0x204, JAL_RA,    3),    # foo → bar
+        (0x300, NOP,       4),
+        (0x304, RET_INSTR, 5),    # bar ret
+        (0x208, NOP,       6),    # back in foo
+        (0x20c, RET_INSTR, 7),    # foo ret
+        (0x108, NOP,       8),    # back in main
+    ])
+    assert stack_names(p) == ["main"]
+    history = history_strings(p)
+    assert any("main;foo;bar" in s for s in history)
+    assert any(s.endswith("main;foo") for s in history)
+
+
+# ----- the bug-#1 cases ---------------------------------------------------------
+
+def test_unconditional_jump_within_function_does_not_push():
+    """Bug #1 used to treat `j label` as a call. It must not."""
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,    0),
+        (0x104, JAL_X0, 1),       # j label (rd = x0) inside main
+        (0x120, NOP,    2),       # still inside main
+    ])
+    assert stack_names(p) == ["main"]
+    # No spurious frame should have been recorded.
+    assert all("main;main" not in s for s in history_strings(p))
+
+
+def test_tail_call_via_jal_x0_replaces_frame():
+    """A tail call must replace the caller's frame, not stack on top of it."""
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,    0),
+        (0x104, JAL_X0, 1),       # main: tail call to foo (rd = x0)
+        (0x200, NOP,    2),       # foo entry
+    ])
+    # main has been replaced by foo — depth must still be 1.
+    assert stack_names(p) == ["foo"]
+
+
+def test_chained_tail_calls_keep_depth_constant():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,    0),
+        (0x104, JAL_X0, 1),       # main → foo (tail)
+        (0x200, NOP,    2),
+        (0x204, JAL_X0, 3),       # foo  → bar (tail)
+        (0x300, NOP,    4),
+        (0x304, JAL_X0, 5),       # bar  → baz (tail)
+        (0x400, NOP,    6),
+    ])
+    assert stack_names(p) == ["baz"]
+
+
+def test_indirect_jump_to_other_function_is_tail_call():
+    """`jalr x0, 0(a0)` to a different function = tail call via fn pointer."""
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,    0),
+        (0x104, JR_A0,  1),       # main: jr a0 (rs1 = a0, not a link reg)
+        (0x200, NOP,    2),       # lands in foo
+    ])
+    assert stack_names(p) == ["foo"]
+
+
+def test_function_pointer_call_pushes_frame():
+    """`jalr ra, 0(a0)` is a real call and must push."""
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,        0),
+        (0x104, JALR_RA_A0, 1),
+        (0x200, NOP,        2),
+        (0x204, RET_INSTR,  3),
+        (0x108, NOP,        4),
+    ])
+    assert stack_names(p) == ["main"]
+    assert any(s.endswith("main;foo") for s in history_strings(p))
+
+
+# ----- branches -----------------------------------------------------------------
+
+def test_branch_does_not_push_frame():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP, 0),
+        (0x104, BEQ, 1),          # branch backwards
+        (0x100, NOP, 2),          # taken — back to top of main
+    ])
+    assert stack_names(p) == ["main"]
+
+
+def test_branch_not_taken():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP, 0),
+        (0x104, BEQ, 1),
+        (0x108, NOP, 2),          # not taken — fall through
+    ])
+    assert stack_names(p) == ["main"]
+
+
+# ----- pipeline-stall dedupe ----------------------------------------------------
+
+def test_repeated_event_is_deduplicated():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP, 0),
+        (0x100, NOP, 1),          # same pc/instr — pipeline stall
+        (0x100, NOP, 2),
+        (0x104, NOP, 3),
+    ])
+    # Stack must not contain duplicate main entries; CallStack.call dedupes
+    # but the more important property is that no spurious history was created.
+    assert stack_names(p) == ["main"]
+    assert all("main;main" not in s for s in history_strings(p))
+
+
+# ----- function-range lookup ----------------------------------------------------
+
+def test_func_at_lookup():
+    p = TraceProcessor(FUNCS)
+    assert p.func_at(0x100) == "main"
+    assert p.func_at(0x140) == "main"
+    assert p.func_at(0x141) is None
+    assert p.func_at(0x200) == "foo"
+    assert p.func_at(0x0FF) is None
+    assert p.func_at(0x500) is None
+
+
+# ----- mcycle attribution -------------------------------------------------------
+
+def test_mcycle_durations_are_recorded():
+    p = TraceProcessor(FUNCS)
+    feed(p, [
+        (0x100, NOP,       0),
+        (0x104, JAL_RA,   10),    # main: call foo at cycle 10
+        (0x200, NOP,      11),
+        (0x204, RET_INSTR, 50),   # foo runs for ~40 cycles
+        (0x108, NOP,      51),
+    ])
+    foo_entries = [d for s, d in p.cs.call_stack_history if s.endswith("foo")]
+    assert foo_entries, "no foo frame recorded"
+    # foo's frame should have a duration > 0 and <= the elapsed mcycles.
+    assert all(d > 0 for d in foo_entries)
+    assert all(d <= 51 for d in foo_entries)


### PR DESCRIPTION
## Summary

- **Bug #1 (rd discrimination):** the old `count_function` classified every JAL/JALR as a CALL based purely on the opcode. `j label` (`jal x0`), tail calls (`jal x0` / `jalr x0` to a different function), and indirect jumps via `jalr x0, rs1!=ra` were all treated as real function calls and inflated stack depth.
- **Bug #2 (overlapping state):** the state machine chained `if (state == "BR"):` / `if (state == "CALL"):` / `if (state == "RET"):` instead of using `elif`. When the BR handler transitioned to CALL/RET inside an event, the next state's handler immediately re-entered with the *current* event's `(addr, instr, mcycle)` — which had nothing to do with the corner-case instruction left in the buffer. The stack silently desynced at every BR-into-corner-case event.
- New `rv_profile.decoder.classify(instr)` returns `NORMAL` / `CALL` / `RET` / `JUMP` / `BRANCH`. A real call requires `rd ∈ {ra, t0}`; `rd == x0` is `JUMP`. Standard + compressed encodings, plus `mret`. Compressed `c.mv` / `c.add` / `c.ebreak` (which share funct3 with `c.jr` / `c.jalr`) are correctly excluded.
- New `TraceProcessor` replaces the buffer-and-look-ahead logic with a single-instruction lookback: when event `n` arrives, the kind of `instr_{n-1}` tells the processor what control-flow transition just landed it at `pc_n`. Cross-function `JUMP` / `BRANCH` is treated as a tail call (synthetic `ret`). Function lookup uses `bisect` (O(log F) per event instead of O(F)).
- `wal.core` is now imported lazily inside `riscv_profile_main`, so the module is unit-testable without the `wal-lang` dep installed.
- New `tests/` directory with **34 passing tests** covering instruction encodings, basic call/return, nested calls, tail calls (single + chained), indirect tail calls, function-pointer calls, branches not pushing frames, pipeline-stall dedupe, function-range lookup boundaries, and mcycle attribution.

## Files

- `src/rv_profile/decoder.py` *(new)* — `classify()` and instruction-kind constants
- `src/rv_profile/rv_profile.py` *(rewritten)* — `TraceProcessor` + `riscv_profile_main`
- `tests/test_decoder.py` *(new)* — 21 tests for the decoder
- `tests/test_trace_processor.py` *(new)* — 13 tests for the state machine

## Test plan

- [x] `pytest tests/` passes locally (34/34)
- [ ] Run `rv_profile` against each of the four committed FSTs (`cv32e20`, `cv32e40p`, `cv32e40px`, `cv32e40x`) and eyeball the resulting flamegraphs
- [ ] Confirm the regression-flamegraphs CI workflow stays green and the published artifacts look sane
- [ ] Spot-check a trace that exercises tail calls (e.g. a recursive function compiled with `-O2`) — the new output should show shallower stacks than the old one for the same workload

## Heads up

The new algorithm **will produce different SVGs** than the previous one for the existing committed FSTs — that is the whole point. Reviewers should diff the artifacts from this PR's CI run against the current ones on `main` and check that the differences match expectations (fewer spurious frames, shallower tail-call chains, no missing real calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)